### PR TITLE
[dunfell] systemd-conf: add leading space to SRC_URI_append

### DIFF
--- a/recipes-core/systemd/systemd-conf_%.bbappend
+++ b/recipes-core/systemd/systemd-conf_%.bbappend
@@ -10,7 +10,7 @@ SRC_URI += " \
     ${@bb.utils.contains("MACHINE_FEATURES", "can", "file://can0.service", "", d)} \
 "
 
-SRC_URI_append_mx6ul = "file://cpuidle-disable-state.rules"
+SRC_URI_append_mx6ul = " file://cpuidle-disable-state.rules"
 
 SYSTEMD_SERVICE_${PN} = "${@bb.utils.contains("MACHINE_FEATURES", "can", "can0.service", "", d)}"
 


### PR DESCRIPTION
https://docs.yoctoproject.org/bitbake/bitbake-user-manual/bitbake-user-manual-metadata.html#appending-and-prepending-override-style-syntax

> When you use this syntax, no spaces are inserted.
> Note: You must control all spacing when you use the override syntax.

W/o the leading space it concatenates the new value to the end of the old one
and breaks the build!

Signed-off-by: Denys Dmytriyenko <denys@konsulko.com>